### PR TITLE
feat: melhorar UX dos spinners de carregamento

### DIFF
--- a/src/app/admin/filmes/page.tsx
+++ b/src/app/admin/filmes/page.tsx
@@ -76,7 +76,9 @@ export default function FilmesPage() {
   };
 
   if (loading) {
-    return <Loading fullScreen text="Carregando filmes..." />;
+    return (
+      <Loading fullScreen text="Carregando filmes..." className="text-white" />
+    );
   }
 
   if (error) {

--- a/src/app/admin/reservas/page.tsx
+++ b/src/app/admin/reservas/page.tsx
@@ -88,7 +88,7 @@ export default function ReservasPage() {
     return (
       <div className="flex-1 flex items-center justify-center p-6">
         <div className="text-center">
-          <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4" />
+          <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4 text-white" />
           <p className="text-muted-foreground">Carregando reservas...</p>
         </div>
       </div>

--- a/src/app/admin/sessoes/page.tsx
+++ b/src/app/admin/sessoes/page.tsx
@@ -135,7 +135,7 @@ export default function SessoesPage() {
     return (
       <div className="flex-1 flex items-center justify-center p-6">
         <div className="text-center">
-          <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4" />
+          <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4 text-white" />
           <p className="text-muted-foreground">Carregando sessões...</p>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -249,14 +249,21 @@ export default function HomePage() {
       <section className="container mx-auto px-4 pb-12">
         <div className="mb-6">
           <h3 className="text-2xl font-bold text-white mb-2">
-            Em Cartaz ({filmesFiltrados.length} filmes)
+            Em Cartaz ({loading ? "..." : filmesFiltrados.length} filmes)
           </h3>
           <p className="text-muted-foreground">
             Confira nossa programação e reserve seu lugar
           </p>
         </div>
 
-        {filmesFiltrados.length === 0 ? (
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <div className="text-center">
+              <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4 text-white" />
+              <p className="text-muted-foreground">Carregando filmes...</p>
+            </div>
+          </div>
+        ) : filmesFiltrados.length === 0 ? (
           <Card>
             <CardContent className="py-12 text-center">
               <Film className="h-16 w-16 mx-auto mb-4 text-muted-foreground" />

--- a/src/components/admin/admin-header.tsx
+++ b/src/components/admin/admin-header.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Plus, ArrowLeft } from "lucide-react";
+import { Plus, ArrowLeft, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useCallback } from "react";
 
@@ -28,6 +28,10 @@ const pageConfig = {
       href: "/admin/sessoes/nova",
       icon: Plus,
     },
+  },
+  "/admin/reservas": {
+    title: "Gerenciar Reservas",
+    subtitle: "Visualize e gerencie todas as reservas",
   },
   "/admin/relatorios": {
     title: "Relatórios",
@@ -82,14 +86,26 @@ export function AdminHeader() {
   if (!currentPage) {
     return (
       <header className="bg-card border-b border-border px-6 py-4">
-        <div className="flex items-center">
-          <Link href="/admin">
-            <Button variant="ghost" size="sm" className="mr-4 btn-voltar">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              <span>Voltar</span>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center">
+            <Link href="/admin">
+              <Button variant="ghost" size="sm" className="mr-4 btn-voltar">
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                <span>Voltar</span>
+              </Button>
+            </Link>
+            <h1 className="text-2xl font-semibold text-foreground">Admin</h1>
+          </div>
+          <Link href="/">
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex items-center gap-2"
+            >
+              <ExternalLink className="h-4 w-4" />
+              <span>Ver Site</span>
             </Button>
           </Link>
-          <h1 className="text-2xl font-semibold text-foreground">Admin</h1>
         </div>
       </header>
     );
@@ -133,6 +149,17 @@ export function AdminHeader() {
               </Button>
             </Link>
           )}
+
+          <Link href="/">
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex items-center gap-2"
+            >
+              <ExternalLink className="h-4 w-4" />
+              <span className="hidden sm:inline">Ver Site</span>
+            </Button>
+          </Link>
         </div>
       </div>
     </header>

--- a/src/components/admin/sidebar.tsx
+++ b/src/components/admin/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { Film, Calendar, Home, Menu, X } from "lucide-react";
+import { Film, Calendar, Home, Menu, X, Ticket } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 
@@ -23,6 +23,11 @@ const navigation = [
     name: "Sessões",
     href: "/admin/sessoes",
     icon: Calendar,
+  },
+  {
+    name: "Reservas",
+    href: "/admin/reservas",
+    icon: Ticket,
   },
 ];
 


### PR DESCRIPTION
- Adicionar seção Reservas na sidebar do dashboard com ícone de ticket
- Adicionar botão 'Ver Site' no header do dashboard para voltar ao site principal
- Tornar spinners do dashboard brancos para melhor visibilidade
- Modificar página principal para mostrar spinner apenas na região dos cards
- Manter estrutura da página visível durante carregamento (header, hero, filtros)